### PR TITLE
Update ``filename`` variable to convert ``\`` to ``/`` for compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,16 +43,21 @@ runs:
         echo "Creating disk image..."
         '& "$Env:PROGRAMFILES (x86)\ImgBurn\ImgBurn.exe" /MODE "BUILD" /BUILDINPUTMODE "STANDARD" /BUILDOUTPUTMODE "IMAGEFILE" /SRC "${{ github.WORKSPACE }}\${{ inputs.path }}" /DEST "${{ github.WORKSPACE }}\${{ inputs.filename }}" /FILESYSTEM "ISO9660 + Joliet" /VOLUMELABEL_ISO9660 "${{ inputs.label }}" /VOLUMELABEL_JOLIET "${{ inputs.label }}" /OVERWRITE YES /ROOTFOLDER YES /START /CLOSE /NOIMAGEDETAILS'
       shell: pwsh
+    - name: Set '\' to '/'
+      id: set_frontslash
+      run: |
+        $Env:DISK_FILENAME = "${{ inputs.filename }}"
+        $Env:DISK_FILENAME = ($Env:DISK_FILENAME -replace '\','/')
+      shell: pwsh
     - name: Upload disk image binary as an artifact
       id: upload_artifact
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.filename }}
-        path: ${{ github.WORKSPACE }}\${{ inputs.filename }}
+        path: ./$Env:DISK_FILENAME
     - name: Push changes with Git
       id: push_changes
       run: |
-        
         echo "Pushing changes to Git."
         timeout /t 1 > nul
         echo "Pushing changes to Git.."


### PR DESCRIPTION
This will update all the ``filename`` variables to use ``/`` instead of ``\`` if a path to store the file is specified in the ``filename`` variable. This is to make it compatible with the ``upload-artifact`` action, and fix problems for not finding the file.